### PR TITLE
Use "plugin" for load other rubocop gems

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
 


### PR DESCRIPTION
@ippachi 
To ignore the warning.

```
rubocop-performance extension supports plugin, specify plugins: rubocop-performance instead of require: rubocop-performance in /Users/yamaji/Lab/nipponsteel-sample-impurity-detection/web/vendor/bundle/ruby/3.4.0/bundler/gems/rubocop-dobado-omakase-aff5b8a66aca/rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rails extension supports plugin, specify plugins: rubocop-rails instead of require: rubocop-rails in /Users/yamaji/Lab/nipponsteel-sample-impurity-detection/web/vendor/bundle/ruby/3.4.0/bundler/gems/rubocop-dobado-omakase-aff5b8a66aca/rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```