### PR TITLE
Add ClassLength  CountAsOne(array/hash)

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -34,3 +34,8 @@ Metrics/MethodLength:
   CountAsOne:
     - hash
     - array
+
+Metrics/ClassLength:
+  CountAsOne:
+    - array
+    - hash


### PR DESCRIPTION
I added it because `Metrics/MethodLength`'s `CountAsOne` does not cover `ClassLength`.